### PR TITLE
Add way to terminate workers

### DIFF
--- a/src/executor/TvmRunner.ts
+++ b/src/executor/TvmRunner.ts
@@ -31,4 +31,12 @@ export class TvmRunnerAsynchronous implements TvmRunner  {
         }
         return TvmRunnerAsynchronous.shared
     }
+
+    public canCleanup() {
+      return this.pool.canCleanup()
+    }
+
+    public async cleanup() {
+      return this.pool.cleanup()
+    }
 }

--- a/src/executor/workerPool/workerPool.spec.ts
+++ b/src/executor/workerPool/workerPool.spec.ts
@@ -36,5 +36,6 @@ describe('ExecutorPool', () => {
             pr.push(pool.execute(config as any))
         }
         await Promise.all(pr)
+        await pool.cleanup()
     })
 })

--- a/src/smartContract/SmartContract.spec.ts
+++ b/src/smartContract/SmartContract.spec.ts
@@ -6,6 +6,7 @@ import {
 import BN from "bn.js";
 import {cellToBoc} from "../utils/cell";
 import {SendMsgAction} from "../utils/parseActionList";
+import { TvmRunnerAsynchronous } from "../executor/TvmRunner";
 
 describe('SmartContract', () => {
     it('should run basic contract', async () => {
@@ -296,5 +297,10 @@ describe('SmartContract', () => {
         let contract = await SmartContract.fromFuncSource(source, new Cell())
         let res = await contract.invokeGetMethod('test', [])
         expect(res.exit_code).toEqual(777)
+    })
+
+    afterAll(async () => {
+      // close all opened threads
+      await TvmRunnerAsynchronous.getShared().cleanup()
     })
 })

--- a/src/smartContract/SmartContract.ts
+++ b/src/smartContract/SmartContract.ts
@@ -3,7 +3,6 @@ import {
     buildC7,
     C7Config,
     getSelectorForMethod,
-    runTVM,
     TVMStack,
     TVMStackEntry,
     TVMStackEntryTuple
@@ -100,7 +99,7 @@ export class SmartContract {
         this.config = {
             getMethodsMutate: config?.getMethodsMutate ?? false,
             debug: config?.debug ?? false,
-            runner: TvmRunnerAsynchronous.getShared()
+            runner: config?.runner ?? TvmRunnerAsynchronous.getShared()
         }
     }
 

--- a/src/vm-exec/vmExec.ts
+++ b/src/vm-exec/vmExec.ts
@@ -19,6 +19,7 @@ async function getInstance() {
     instance = await VmExec()
     // Notify all waiters
     waiters.map(w => w(instance))
+    waiters = []
     return instance
 }
 


### PR DESCRIPTION
- Fixed jest warning (also useful to gracefull exit from server code)
```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.
```
<img width="604" alt="jest-warning" src="https://user-images.githubusercontent.com/8437497/175785178-55a1fcda-4d34-43bd-af63-c9d2192df995.png">

<img width="728" alt="open handlers" src="https://user-images.githubusercontent.com/8437497/175785196-83569333-55f0-4a8d-9496-4f5e4cb36171.png">

- Creating worker on demand



